### PR TITLE
chore: activate stale PRs workflow for repo

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,11 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    # Run daily at 10:00 AM UTC
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale-prs:
+    uses: lafourchette/github-actions/.github/workflows/stale-prs.yml@v1


### PR DESCRIPTION
Activate automated stale PR management workflow.

**How it works:**
- PRs with no activity for 7 days receive a stale warning
- After 21 days total (7 + 14), PRs are automatically closed
- Branch is deleted (can be restored if needed)

**Safety mechanisms:**
- Any activity resets the timer
- Remove "stale" label to prevent closure
- Add "do-not-close" label to exempt critical PRs
- Closed PRs can be reopened anytime

**Context:**
Approved by Architecture Board (CONCERN-558) to reduce 1,000+ stale PRs organization-wide.
Already running successfully on 162 repos.